### PR TITLE
Change: fix typo in save audio for api doc

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -41,7 +41,7 @@ separator.update_parameter(segment=smaller_segment)
 # Remember to create the destination folder before calling `save_audio`
 # Or you are likely to receive `FileNotFoundError`
 for stem, source in separated.items():
-    demucs.api.save_audio(source, f"{stem}_file.mp3", samplerate=separator.samplerate)
+    demucs.api.save_audio(source, f"{stem}_file.mp3", separator.samplerate)
 ```
 
 ## API References

--- a/docs/api.md
+++ b/docs/api.md
@@ -39,9 +39,9 @@ separator.update_parameter(segment=smaller_segment)
 
 ```python
 # Remember to create the destination folder before calling `save_audio`
-# Or you are likely to recieve `FileNotFoundError`
+# Or you are likely to receive `FileNotFoundError`
 for stem, source in separated.items():
-    demucs.api.save_audio(wav=source, path=f"{stem}_file.mp3", samplerate=separator.samplerate)
+    demucs.api.save_audio(source, f"{stem}_file.mp3", samplerate=separator.samplerate)
 ```
 
 ## API References

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,9 +40,8 @@ separator.update_parameter(segment=smaller_segment)
 ```python
 # Remember to create the destination folder before calling `save_audio`
 # Or you are likely to recieve `FileNotFoundError`
-for file, sources in separated:
-    for stem, source in sources.items():
-        demucs.api.save_audio(source, f"{stem}_{file}", samplerate=separator.samplerate)
+for stem, source in separated.items():
+    demucs.api.save_audio(wav=source, path=f"{stem}_file.mp3", samplerate=separator.samplerate)
 ```
 
 ## API References


### PR DESCRIPTION
Hi, I was trying to use demuc in a .py file without cli commands. When I tried the below code:

```python
# Remember to create the destination folder before calling `save_audio`
# Or you are likely to recieve `FileNotFoundError`
for stem, source in separated.items():
    demucs.api.save_audio(wav=source, path=f"{stem}_file.mp3", samplerate=separator.samplerate)
```

first I encounterd this error:
`too many values to unpack (expected 2)`

it was refering to the first loop. when I digged in I found out that `separate_audio_file` return a tuple which is origin file and a dict. but few lines above we have this code:

```python
origin, separated = separator.separate_audio_file("file.mp3")
```

as you can see, separated is now has the dict part of that tuple, so we face an error here.
After fixing that with some code like below:

```python
for file, sources in separator.separate_audio_file("file.mp3"):
    for stem, source in sources.items():
        demucs.api.save_audio(source, f"{stem}_{file}", samplerate=separator.samplerate)
```

we face another error which is:
`'Tensor' object has no attribute 'items'`

I found out that first loop is not working, so I made some changes and decided to change doc for api section.
I was hoping it helps other people facing these errors.