### PR TITLE
fix: issue with tensor not being on the right device when using separate_audio_file

### DIFF
--- a/demucs/api.py
+++ b/demucs/api.py
@@ -305,7 +305,7 @@ class Separator:
         are the name of stems and values are separated waves. The original wave will have already
         been resampled.
         """
-        return self.separate_tensor(self._load_audio(file), self.samplerate)
+        return self.separate_tensor(self._load_audio(file).to(self._device), self.samplerate)
 
     @property
     def samplerate(self):


### PR DESCRIPTION
Previously `Input type (torch.cuda.FloatTensor) and weight type (torch.FloatTensor) should be the same` if you had the model on cuda, this should move the tensor to the right place.