### PR TITLE
Fix a problem about numpy

### DIFF
--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -10,6 +10,7 @@ dependencies:
   - pytorch>=1.8.1
   - torchaudio>=0.8
   - tqdm>=4.36
+  - numpy<2.0
   - pip
   - pip:
     - diffq>=0.2

--- a/environment-cuda.yml
+++ b/environment-cuda.yml
@@ -12,6 +12,7 @@ dependencies:
   - cudatoolkit>=10
   - tqdm>=4.36
   - pip
+  - numpy<2.0
   - pip:
     - diffq>=0.2
     - dora-search


### PR DESCRIPTION
I'm not good at English, so I use a translator.

I installed demucs using conda as per README. but while using it, it reports an error.


A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.2 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.

Traceback (most recent call last):  File "\\?\C:\Users\01\.conda\envs\demucs\Scripts\demucs-script.py", line 33, in <module>
    sys.exit(load_entry_point('demucs', 'console_scripts', 'demucs')())
  File "\\?\C:\Users\01\.conda\envs\demucs\Scripts\demucs-script.py", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "C:\Users\01\.conda\envs\demucs\lib\importlib\metadata.py", line 86, in load
    module = import_module(match.group('module'))
  File "C:\Users\01\.conda\envs\demucs\lib\importlib\__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "c:\users\01\demucs\demucs\separate.py", line 11, in <module>
    from dora.log import fatal
  File "C:\Users\01\.conda\envs\demucs\lib\site-packages\dora\__init__.py", line 66, in <module>
    from .explore import Explorer, Launcher
  File "C:\Users\01\.conda\envs\demucs\lib\site-packages\dora\explore.py", line 27, in <module>
    from .shep import Shepherd, Sheep
  File "C:\Users\01\.conda\envs\demucs\lib\site-packages\dora\shep.py", line 25, in <module>
    from .distrib import get_distrib_spec
  File "C:\Users\01\.conda\envs\demucs\lib\site-packages\dora\distrib.py", line 14, in <module>
    import torch
  File "C:\Users\01\.conda\envs\demucs\lib\site-packages\torch\__init__.py", line 1382, in <module>
    from .functional import *  # noqa: F403
  File "C:\Users\01\.conda\envs\demucs\lib\site-packages\torch\functional.py", line 7, in <module>
    import torch.nn.functional as F
  File "C:\Users\01\.conda\envs\demucs\lib\site-packages\torch\nn\__init__.py", line 1, in <module>
    from .modules import *  # noqa: F403
  File "C:\Users\01\.conda\envs\demucs\lib\site-packages\torch\nn\modules\__init__.py", line 35, in <module>
    from .transformer import TransformerEncoder, TransformerDecoder, \
  File "C:\Users\01\.conda\envs\demucs\lib\site-packages\torch\nn\modules\transformer.py", line 20, in <module>
    device: torch.device = torch.device(torch._C._get_default_device()),  # torch.device('cpu'),
C:\Users\01\.conda\envs\demucs\lib\site-packages\torch\nn\modules\transformer.py:20: UserWarning: Failed to initialize NumPy: _ARRAY_API not found (Triggered internally at C:\actions-runner\_work\pytorch\pytorch\builder\windows\pytorch\torch\csrc\utils\tensor_numpy.cpp:84.)
  device: torch.device = torch.device(torch._C._get_default_device()),  # torch.device('cpu'),
c:\users\01\demucs\demucs\api.py:27: UserWarning: TorchAudio's global backend is now deprecated. Please enable distpatcher by setting `TORCHAUDIO_USE_BACKEND_DISPATCHER=1`, and specify backend when calling load/info/save function.
  import torchaudio as ta
Selected model is a bag of 1 models. You will see that many progress bars per track.
Separated tracks will be stored in C:\Users\01\separated\htdemucs
File hdemucs_mmi does not exist. If the path contains spaces, please try again after surrounding the entire path with quotes "".
Separating track C:\Users\01\Music\Mitsukiyo - Honey Jam.mp3
Traceback (most recent call last):
  File "\\?\C:\Users\01\.conda\envs\demucs\Scripts\demucs-script.py", line 33, in <module>
    sys.exit(load_entry_point('demucs', 'console_scripts', 'demucs')())
  File "c:\users\01\demucs\demucs\separate.py", line 168, in main
    origin, res = separator.separate_audio_file(track)
  File "c:\users\01\demucs\demucs\api.py", line 308, in separate_audio_file
    return self.separate_tensor(self._load_audio(file), self.samplerate)
  File "c:\users\01\demucs\demucs\api.py", line 216, in _load_audio
    wav = AudioFile(track).read(streams=0, samplerate=self._samplerate,
  File "c:\users\01\demucs\demucs\audio.py", line 131, in read
    wav = torch.from_numpy(wav)
RuntimeError: Numpy is not available


I found an [issue](https://github.com/facebookresearch/demucs/issues/614) with the same question as mine.It looks like the numpy installation needs to be limited to version 2.0 or less, so I submitted this PR
