### PR TITLE
Loosen torchaudio version in requirements_minimal.txt

### DIFF
--- a/requirements_minimal.txt
+++ b/requirements_minimal.txt
@@ -6,5 +6,5 @@ lameenc>=1.2
 openunmix
 pyyaml
 torch>=1.8.1
-torchaudio>=0.8,<2.2
+torchaudio>=0.8
 tqdm

--- a/requirements_minimal.txt
+++ b/requirements_minimal.txt
@@ -6,5 +6,5 @@ lameenc>=1.2
 openunmix
 pyyaml
 torch>=1.8.1
-torchaudio>=0.8
+torchaudio>=0.8,<2.9
 tqdm


### PR DESCRIPTION
Hi! This pull request loosens the dependency version for `torchaudio` in `requirements_minimal.txt`.

If I understand the README correctly, there are two sets of dependencies:
- `requirements_minimal.txt` for simple stem separation. This is what's used when installing via `pip install demucs`.
- `requirements.txt` or `environment-[cpu|cuda].yml`. This is for training.

Training requires torchaudio<2.2, but stem separation appears to work correctly with later versions of torchaudio (see https://github.com/adefossez/demucs/pull/7). Therefore, I think the dependencies in `requirements_minimal.txt` can be safely loosened to allow later torchaudio versions. I have tested stem separation with torchaudio 2.8.0 and everything appears to work correctly.