### PR TITLE
Support ONNX export for Demucs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ Session.vim
 /misc
 /mdx
 .mypy_cache
+*.onnx
+*.ort
+*.config

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ Session.vim
 /release
 /release_models
 /separated
-/tests
 /trash
 /misc
 /mdx

--- a/demucs/htdemucs.py
+++ b/demucs/htdemucs.py
@@ -130,6 +130,7 @@ class HTDemucs(nn.Module):
         samplerate=44100,
         segment=10,
         use_train_segment=True,
+        onnx_exportable=False,
     ):
         """
         Args:
@@ -239,6 +240,7 @@ class HTDemucs(nn.Module):
         self.wiener_iters = wiener_iters
         self.end_iters = end_iters
         self.freq_emb = None
+        self.onnx_exportable = onnx_exportable
         assert wiener_iters == end_iters
 
         self.encoder = nn.ModuleList()
@@ -434,18 +436,30 @@ class HTDemucs(nn.Module):
         pad = hl // 2 * 3
         x = pad1d(x, (pad, pad + le * hl - x.shape[-1]), mode="reflect")
 
-        z = spectro(x, nfft, hl)[..., :-1, :]
-        assert z.shape[-1] == le + 4, (z.shape, x.shape, le)
-        z = z[..., 2: 2 + le]
+        if self.onnx_exportable:
+            z = spectro(x, nfft, hl, onnx_exportable=True)[..., :-1, :, :]    # adding one more dimension
+            assert z.shape[-2] == le + 4, (z.shape, x.shape, le) # from -1 to -2
+            z = z[..., 2: 2 + le, :]  # adding one more dimension
+        else:
+            z = spectro(x, nfft, hl)[..., :-1, :]
+            assert z.shape[-1] == le + 4, (z.shape, x.shape, le)
+            z = z[..., 2: 2 + le]
         return z
 
     def _ispec(self, z, length=None, scale=0):
         hl = self.hop_length // (4**scale)
-        z = F.pad(z, (0, 0, 0, 1))
-        z = F.pad(z, (2, 2))
-        pad = hl // 2 * 3
-        le = hl * int(math.ceil(length / hl)) + 2 * pad
-        x = ispectro(z, hl, length=le)
+        if self.onnx_exportable:
+            z = F.pad(z, (0, 0, 0, 0, 0, 1))  # add 0 padding for the last dim
+            z = F.pad(z, (0, 0, 2, 2))  # add 0 padding for the last dim
+            pad = hl // 2 * 3
+            le = hl * int(math.ceil(length / hl)) + 2 * pad
+            x = ispectro(z, hl, length=le, onnx_exportable=True)
+        else:
+            z = F.pad(z, (0, 0, 0, 1))
+            z = F.pad(z, (2, 2))
+            pad = hl // 2 * 3
+            le = hl * int(math.ceil(length / hl)) + 2 * pad
+            x = ispectro(z, hl, length=le)
         x = x[..., pad: pad + length]
         return x
 
@@ -453,11 +467,20 @@ class HTDemucs(nn.Module):
         # return the magnitude of the spectrogram, except when cac is True,
         # in which case we just move the complex dimension to the channel one.
         if self.cac:
-            B, C, Fr, T = z.shape
-            m = torch.view_as_real(z).permute(0, 1, 4, 2, 3)
+            if self.onnx_exportable:
+                B, C, Fr, T, dim = z.shape  # dim should be 2, adding one more dimension
+                m = z.permute(0, 1, 4, 2, 3) # torch.view_as_real(z) changed to z 
+            else:
+                B, C, Fr, T = z.shape
+                m = torch.view_as_real(z).permute(0, 1, 4, 2, 3)
             m = m.reshape(B, C * 2, Fr, T)
         else:
-            m = z.abs()
+            if self.onnx_exportable:
+                real = z[..., 0]
+                imag = z[..., 1]
+                m = torch.sqrt(real**2 + imag**2)  # for magnitude
+            else:         
+                m = z.abs()
         return m
 
     def _mask(self, z, m):
@@ -467,8 +490,12 @@ class HTDemucs(nn.Module):
         if self.cac:
             B, S, C, Fr, T = m.shape
             out = m.view(B, S, -1, 2, Fr, T).permute(0, 1, 2, 4, 5, 3)
-            out = torch.view_as_complex(out.contiguous())
+            if self.onnx_exportable:
+                out = out.contiguous()  # out shape is (B, S, -1, Fr, T, 2) shape
+            else:
+                out = torch.view_as_complex(out.contiguous())   # out shape is (B, S, -1, Fr, T)  (complex)
             return out
+        # TODO: Modify all the below paths for the new shape
         if self.training:
             niters = self.end_iters
         if niters < 0:

--- a/demucs/istft.py
+++ b/demucs/istft.py
@@ -1,0 +1,164 @@
+# Copyright (C) 2025 Mixxx Development Team
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+# First author is Anmol Mishra.
+"""
+This module implements a custom ISTFT process that is compatible with ONNX export.
+It uses PyTorch's convolution operations to compute the inverse STFT, avoiding the use of
+complex numbers directly, which can be problematic for ONNX export.
+"""
+import torch
+import enum
+
+
+# Constants set for Demucs
+NFFT = 4096                                         # Number of FFT components for the STFT process
+HOP_LENGTH = 1024                                   # Number of samples between successive frames in the STFT
+WINDOW_TYPE = 'hann'                                # Type of window function used in the STFT
+WINDOW_LENGTH = NFFT                                # Length of the window function
+NORMALIZED = True                                   # Whether to normalize the window function
+MAX_SIGNAL_LENGTH = int(44100 * 8)                  # Maximum length of the audio signal WITH padding (8 seconds at 44100 Hz)
+MAX_FRAMES = MAX_SIGNAL_LENGTH // HOP_LENGTH + 1    # Maximum number of frames for the audio length after STFT processed.
+CENTER = True                                       # Whether to center the input signal before STFT
+
+# Enum for window types 
+class WindowType(enum.StrEnum):
+    BARTLETT = 'bartlett'
+    BLACKMAN = 'blackman'
+    HAMMING = 'hamming'
+    HANN = 'hann'
+    KAISER = 'kaiser'
+
+    def __call__(self, window_length):
+        match self:
+            case WindowType.BARTLETT:
+                return torch.bartlett_window(window_length)
+            case WindowType.BLACKMAN:
+                return torch.blackman_window(window_length)
+            case WindowType.HAMMING:
+                return torch.hamming_window(window_length)
+            case WindowType.HANN:
+                return torch.hann_window(window_length)
+            case WindowType.KAISER:
+                return torch.kaiser_window(window_length, periodic=True, beta=12.0)
+            case _:
+                raise NotImplementedError(f"Window type {self} doesn't yet have a function.") 
+
+class ISTFT_Process(torch.nn.Module):
+    def __init__(self, n_fft=NFFT, hop_len=HOP_LENGTH, window_type=WINDOW_TYPE, window_length=WINDOW_LENGTH, normalized=NORMALIZED, max_frames=MAX_FRAMES, center=CENTER):
+        super(ISTFT_Process, self).__init__()
+        self.n_fft = n_fft
+        self.hop_len = hop_len
+        self.window_type = window_type
+        self.window_length = window_length
+        self.normalized = normalized
+        self.max_frames = max_frames
+        self.center = center
+        self.half_n_fft = n_fft // 2  # Precompute once
+
+        # Get window function and compute window once
+        if self.window_length != self.n_fft:
+            raise NotImplementedError(f"The case of window length not equal to n_fft is not implemented in {self.__class__.__name__}.")
+        window = WindowType(window_type)(self.window_length).float()
+
+        # Check if center is false
+        if not self.center:
+            raise NotImplementedError("No centering is not supported in this implementation.")
+
+        # ISTFT forward pass preparation
+        # Pre-compute fourier basis
+        fourier_basis = torch.fft.fft(torch.eye(n_fft, dtype=torch.float32))
+        fourier_basis = torch.vstack([
+            torch.real(fourier_basis[:self.half_n_fft + 1, :]),
+            torch.imag(fourier_basis[:self.half_n_fft + 1, :])
+        ]).float()
+        
+        # Create forward and inverse basis
+        forward_basis = window * fourier_basis[:, None, :]
+        inverse_basis = window * torch.linalg.pinv((fourier_basis * n_fft) / hop_len).T[:, None, :]
+        
+        # Calculate window sum for overlap-add
+        n = n_fft + hop_len * (max_frames - 1)
+        window_sum = torch.zeros(n, dtype=torch.float32)
+        window_normalized = window / window.abs().max()
+        
+        # Pad window if needed
+        total_pad = n_fft - window_normalized.shape[0]
+        if total_pad > 0:
+            pad_left = total_pad // 2
+            pad_right = total_pad - pad_left
+            win_sq = torch.nn.functional.pad(window_normalized ** 2, (pad_left, pad_right), mode='constant', value=0)
+        else:
+            win_sq = window_normalized ** 2
+        
+        # Calculate overlap-add weights
+        for i in range(max_frames):
+            sample = i * hop_len
+            window_sum[sample: min(n, sample + n_fft)] += win_sq[: max(0, min(n_fft, n - sample))]
+        
+        # Normalize window if needed
+        if normalized:
+            inverse_basis = inverse_basis * torch.sqrt(torch.tensor([n_fft], dtype=torch.float32))
+        
+        # Register buffers
+        self.register_buffer("forward_basis", forward_basis)
+        self.register_buffer("inverse_basis", inverse_basis)
+        self.register_buffer("window_sum_inv", n_fft / (window_sum * hop_len + 1e-8))  # Add epsilon to avoid division by zero
+
+    def forward(self, real, imag, length=None):
+        # Calculate magnitude and phase from real and imaginary parts
+        magnitude = torch.sqrt(real ** 2 + imag ** 2)
+        phase = torch.atan2(imag, real + torch.finfo(real.dtype).eps)  # Add epsilon to avoid division by zero
+
+        # Pre-compute trig values
+        cos_phase = torch.cos(phase)
+        sin_phase = torch.sin(phase)
+        
+        # Prepare input for transposed convolution
+        complex_input = torch.cat((magnitude * cos_phase, magnitude * sin_phase), dim=1)
+        
+        # Perform transposed convolution
+        inverse_transform = torch.nn.functional.conv_transpose1d(
+            complex_input,
+            self.inverse_basis,
+            stride=self.hop_len,
+            padding=0,
+        )
+        
+        # Apply window correction
+        output_len = inverse_transform.size(-1)
+        start_idx = self.half_n_fft
+        end_idx = output_len
+        
+        output =  inverse_transform[:, :, start_idx:end_idx] * self.window_sum_inv[start_idx:end_idx]
+
+        # If length is specified, trim the output to the desired length
+        if length:
+            pad_len = torch.clamp(torch.tensor(length) - output.size(-1), min=0)
+
+            # Create a zero pad tensor regardless of need
+            pad = torch.zeros(
+                output.size(0), output.size(1), pad_len,
+                dtype=output.dtype, device=output.device
+            )
+
+            # Always cat, pad_len will be 0 if not needed
+            output = torch.cat([output, pad], dim=-1)
+
+            # Crop in all cases to enforce exact length
+            output = output[..., :length]
+
+        output = output.squeeze(dim=1)
+        return output
+
+demucs_istft = ISTFT_Process(
+    n_fft=NFFT,
+    hop_len=HOP_LENGTH,
+    window_type=WINDOW_TYPE,
+    window_length=WINDOW_LENGTH,
+    normalized=NORMALIZED,
+    max_frames=MAX_FRAMES,
+    center=CENTER,
+)

--- a/demucs/spec.py
+++ b/demucs/spec.py
@@ -7,6 +7,7 @@
 """Conveniance wrapper to perform STFT and iSTFT"""
 
 import torch as th
+from .stft import demucs_stft
 
 
 def spectro(x, n_fft=512, hop_length=None, pad=0, onnx_exportable=False):
@@ -17,17 +18,7 @@ def spectro(x, n_fft=512, hop_length=None, pad=0, onnx_exportable=False):
         x = x.cpu()
     
     if onnx_exportable:
-        z = th.view_as_real(
-            th.stft(x,
-                    n_fft * (1 + pad),
-                    hop_length or n_fft // 4,
-                    window=th.hann_window(n_fft).to(x),
-                    win_length=n_fft,
-                    normalized=True,
-                    center=True,
-                    return_complex=True,
-                    pad_mode='reflect')
-        )   # Now z will return 1 more dimension - last dimension will be 2 now
+        z = demucs_stft(x.view(-1, 1, length))    # z will return 1 more dimension - z.size(-1) will be 2
         _, freqs, frame, dim = z.shape
         assert dim == 2, "STFT should return complex numbers"
         return z.view(*other, freqs, frame, dim)

--- a/demucs/spec.py
+++ b/demucs/spec.py
@@ -8,6 +8,7 @@
 
 import torch as th
 from .stft import demucs_stft
+from .istft import demucs_istft
 
 
 def spectro(x, n_fft=512, hop_length=None, pad=0, onnx_exportable=False):
@@ -47,15 +48,7 @@ def ispectro(z, hop_length=None, length=None, pad=0, onnx_exportable=False):
         is_mps_xpu = z.device.type in ['mps', 'xpu']
         if is_mps_xpu:
             z = z.cpu()
-        z = th.view_as_complex(z)  # Convert to complex tensor
-        x = th.istft(z,
-                     n_fft,
-                     hop_length,
-                     window=th.hann_window(win_length).to(z.real),
-                     win_length=win_length,
-                     normalized=True,
-                     length=length,
-                     center=True)
+        x = demucs_istft(z[..., 0], z[..., 1], length=length)
         _, length = x.shape
         return x.view(*other, length)
 

--- a/demucs/spec.py
+++ b/demucs/spec.py
@@ -8,40 +8,78 @@
 import torch as th
 
 
-def spectro(x, n_fft=512, hop_length=None, pad=0):
+def spectro(x, n_fft=512, hop_length=None, pad=0, onnx_exportable=False):
     *other, length = x.shape
     x = x.reshape(-1, length)
     is_mps_xpu = x.device.type in ['mps', 'xpu']
     if is_mps_xpu:
         x = x.cpu()
-    z = th.stft(x,
-                n_fft * (1 + pad),
-                hop_length or n_fft // 4,
-                window=th.hann_window(n_fft).to(x),
-                win_length=n_fft,
-                normalized=True,
-                center=True,
-                return_complex=True,
-                pad_mode='reflect')
-    _, freqs, frame = z.shape
-    return z.view(*other, freqs, frame)
+    
+    if onnx_exportable:
+        z = th.view_as_real(
+            th.stft(x,
+                    n_fft * (1 + pad),
+                    hop_length or n_fft // 4,
+                    window=th.hann_window(n_fft).to(x),
+                    win_length=n_fft,
+                    normalized=True,
+                    center=True,
+                    return_complex=True,
+                    pad_mode='reflect')
+        )   # Now z will return 1 more dimension - last dimension will be 2 now
+        _, freqs, frame, dim = z.shape
+        assert dim == 2, "STFT should return complex numbers"
+        return z.view(*other, freqs, frame, dim)
+    else:
+        z = th.stft(x,
+                    n_fft * (1 + pad),
+                    hop_length or n_fft // 4,
+                    window=th.hann_window(n_fft).to(x),
+                    win_length=n_fft,
+                    normalized=True,
+                    center=True,
+                    return_complex=True,
+                    pad_mode='reflect')
+        _, freqs, frame = z.shape
+        return z.view(*other, freqs, frame)
 
 
-def ispectro(z, hop_length=None, length=None, pad=0):
-    *other, freqs, frames = z.shape
-    n_fft = 2 * freqs - 2
-    z = z.view(-1, freqs, frames)
-    win_length = n_fft // (1 + pad)
-    is_mps_xpu = z.device.type in ['mps', 'xpu']
-    if is_mps_xpu:
-        z = z.cpu()
-    x = th.istft(z,
-                 n_fft,
-                 hop_length,
-                 window=th.hann_window(win_length).to(z.real),
-                 win_length=win_length,
-                 normalized=True,
-                 length=length,
-                 center=True)
+def ispectro(z, hop_length=None, length=None, pad=0, onnx_exportable=False):
+    if onnx_exportable:
+        # B, S, -1, Fr, T  (complex)      ----->     # B, S, -1, Fr, T, 2 shape
+        *other, freqs, frames, dim = z.shape   # dim is 2
+        assert dim == 2, "iSTFT should receive complex numbers"    
+        n_fft = 2 * freqs - 2
+        z = z.view(-1, freqs, frames, dim)
+        win_length = n_fft // (1 + pad)
+        is_mps_xpu = z.device.type in ['mps', 'xpu']
+        if is_mps_xpu:
+            z = z.cpu()
+        z = th.view_as_complex(z)  # Convert to complex tensor
+        x = th.istft(z,
+                    n_fft,
+                    hop_length,
+                    window=th.hann_window(win_length).to(z.real),
+                    win_length=win_length,
+                    normalized=True,
+                    length=length,
+                    center=True)
+    else:
+        *other, freqs, frames = z.shape
+        n_fft = 2 * freqs - 2
+        z = z.view(-1, freqs, frames)
+        win_length = n_fft // (1 + pad)
+        is_mps_xpu = z.device.type in ['mps', 'xpu']
+        if is_mps_xpu:
+            z = z.cpu()
+        x = th.istft(z,
+                    n_fft,
+                    hop_length,
+                    window=th.hann_window(win_length).to(z.real),
+                    win_length=win_length,
+                    normalized=True,
+                    length=length,
+                    center=True)
+    
     _, length = x.shape
     return x.view(*other, length)

--- a/demucs/stft.py
+++ b/demucs/stft.py
@@ -1,0 +1,106 @@
+# Copyright (C) 2025 Mixxx Development Team
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+# First author is Anmol Mishra.
+"""
+This module implements a custom STFT process that is compatible with ONNX export.
+It uses PyTorch's convolution operations to compute the STFT, avoiding the use of complex
+numbers directly, which can be problematic for ONNX export.
+"""
+import torch
+import enum
+
+
+# Constants set for Demucs
+NFFT = 4096                                         # Number of FFT components for the STFT process
+HOP_LENGTH = 1024                                   # Number of samples between successive frames in the STFT
+WINDOW_TYPE = 'hann'                                # Type of window function used in the STFT
+WINDOW_LENGTH = NFFT                                # Length of the window function
+NORMALIZED = True                                   # Whether to normalize the window function
+CENTER = True                                       # Whether to center the input signal before STFT
+PAD_MODE = 'reflect'                                # Select reflect or constant padding mode for the STFT process.
+
+# Enum for window types 
+class WindowType(enum.StrEnum):
+    BARTLETT = 'bartlett'
+    BLACKMAN = 'blackman'
+    HAMMING = 'hamming'
+    HANN = 'hann'
+    KAISER = 'kaiser'
+
+    def __call__(self, window_length):
+        match self:
+            case WindowType.BARTLETT:
+                return torch.bartlett_window(window_length)
+            case WindowType.BLACKMAN:
+                return torch.blackman_window(window_length)
+            case WindowType.HAMMING:
+                return torch.hamming_window(window_length)
+            case WindowType.HANN:
+                return torch.hann_window(window_length)
+            case WindowType.KAISER:
+                return torch.kaiser_window(window_length, periodic=True, beta=12.0)
+            case _:
+                raise NotImplementedError(f"Window type {self} doesn't yet have a function.") 
+
+class STFT_Process(torch.nn.Module):
+    def __init__(self, n_fft=NFFT, hop_len=HOP_LENGTH, window_type=WINDOW_TYPE, window_length=WINDOW_LENGTH, normalized=NORMALIZED, center=CENTER, pad_mode=PAD_MODE):
+        super(STFT_Process, self).__init__()
+        self.n_fft = n_fft
+        self.hop_len = hop_len
+        self.window_type = window_type
+        self.window_length = window_length
+        self.normalized = normalized
+        self.center = center
+        self.pad_mode = pad_mode
+        self.half_n_fft = n_fft // 2  # Precompute once
+        
+        # Get window function and compute window once
+        if self.window_length != self.n_fft:
+            raise NotImplementedError(f"The case of window length not equal to n_fft is not implemented in {self.__class__.__name__}.")
+        window = WindowType(window_type)(self.window_length).float()
+
+        # STFT forward pass preparation
+        time_steps = torch.arange(self.n_fft, dtype=torch.float32).unsqueeze(0)
+        frequencies = torch.arange(self.half_n_fft + 1, dtype=torch.float32).unsqueeze(1)
+        
+        # Calculate omega matrix once
+        omega = 2 * torch.pi * frequencies * time_steps / n_fft
+
+        # Calculate window function
+        cos_kernel = (torch.cos(omega) * window.unsqueeze(0)).unsqueeze(1)
+        sin_kernel = (-torch.sin(omega) * window.unsqueeze(0)).unsqueeze(1)
+
+        # Normalize window if needed
+        if normalized:
+            cos_kernel = cos_kernel / torch.sqrt(torch.tensor([n_fft], dtype=torch.float32))
+            sin_kernel = sin_kernel / torch.sqrt(torch.tensor([n_fft], dtype=torch.float32))
+
+        # Register conv kernels as buffers
+        self.register_buffer('cos_kernel', (cos_kernel))
+        self.register_buffer('sin_kernel', (sin_kernel))
+
+    def forward(self, x):
+        if self.center:
+            x_padded = torch.nn.functional.pad(x, (self.half_n_fft, self.half_n_fft), mode=self.pad_mode)
+        else:
+            x_padded = x
+
+        # Perform convolutions
+        real_part = torch.nn.functional.conv1d(x_padded, self.cos_kernel, stride=self.hop_len)
+        image_part = torch.nn.functional.conv1d(x_padded, self.sin_kernel, stride=self.hop_len)
+
+        # return real_part, image_part
+        return torch.stack((real_part, image_part), dim=-1)
+
+demucs_stft = STFT_Process(
+    n_fft=NFFT,
+    hop_len=HOP_LENGTH,
+    window_type=WINDOW_TYPE,
+    window_length=WINDOW_LENGTH,
+    normalized=NORMALIZED,
+    center=CENTER,
+    pad_mode=PAD_MODE
+)

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -3,11 +3,13 @@
 ## Convert PyTorch model to ONNX and ORT
 
 Convert Demucs PyTorch model to ONNX:
-```
-$ python ./scripts/convert-pth-to-onnx.py ./scripts/demucs-onnx
+
+```python
+python ./scripts/convert-pth-to-onnx.py ./onnx-models
 ```
 
-Then, convert ONNX to ORT:
-```
-$ ./scripts/convert-model-to-ort.sh 
+Optionally, convert ONNX model to ORT:
+
+```python
+python -m onnxruntime.tools.convert_onnx_models_to_ort ./onnx-models --enable_type_reduction 
 ```

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -1,0 +1,13 @@
+# Exporting HTDemucs Model
+
+## Convert PyTorch model to ONNX and ORT
+
+Convert Demucs PyTorch model to ONNX:
+```
+$ python ./scripts/convert-pth-to-onnx.py ./scripts/demucs-onnx
+```
+
+Then, convert ONNX to ORT:
+```
+$ ./scripts/convert-model-to-ort.sh 
+```

--- a/requirements_minimal.txt
+++ b/requirements_minimal.txt
@@ -6,5 +6,5 @@ lameenc>=1.2
 openunmix
 pyyaml
 torch>=1.8.1
-torchaudio>=0.8,<2.2
+torchaudio
 tqdm

--- a/scripts/convert-model-to-ort.sh
+++ b/scripts/convert-model-to-ort.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# copied from https://github.com/olilarkin/ort-builder
+
+python -m onnxruntime.tools.convert_onnx_models_to_ort $1 --enable_type_reduction

--- a/scripts/convert-model-to-ort.sh
+++ b/scripts/convert-model-to-ort.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# copied from https://github.com/olilarkin/ort-builder
-
-python -m onnxruntime.tools.convert_onnx_models_to_ort $1 --enable_type_reduction

--- a/scripts/convert-pth-to-onnx.py
+++ b/scripts/convert-pth-to-onnx.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+import torch
+from torch.nn import functional as F
+import argparse
+from pathlib import Path
+from demucs.pretrained import get_model
+from demucs.htdemucs import HTDemucs
+
+DEMUCS_MODEL = "htdemucs"
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Convert Demucs PyTorch models to ONNX')
+    parser.add_argument("dest_dir", type=str, help="destination path for the converted model")
+
+    args = parser.parse_args()
+
+    dir_out = Path(args.dest_dir)
+    dir_out.mkdir(parents=True, exist_ok=True)
+
+    # Load the appropriate model
+    model = get_model(DEMUCS_MODEL)
+    model_name = DEMUCS_MODEL
+
+    # Check if model is an instance of BagOfModels
+    if isinstance(model, HTDemucs):
+        core_model = model
+    elif hasattr(model, 'models') and isinstance(model.models[0], HTDemucs):
+        core_model = model.models[0]  # Select the first model in BagOfModels
+    else:
+        raise TypeError("Unsupported model type")
+
+    # Set the model to onnx export mode
+    core_model.onnx_exportable = True
+
+    # Prepare a dummy input tensor
+    dummy_waveform = torch.randn(1, 2, 343980)
+    training_length = int(core_model.segment * core_model.samplerate)
+    dummy_waveform = F.pad(dummy_waveform, (0, training_length - dummy_waveform.shape[-1]))
+    dummy_input = (dummy_waveform)
+
+    # Define output file name
+    onnx_file_path = dir_out / f"{model_name}.onnx"
+    print(f"Converting {model_name} to ONNX format...")
+
+    # Export the core model to ONNX
+    try:
+        torch.onnx.export(
+            core_model,
+            dummy_input,
+            onnx_file_path,
+            export_params=True,
+            opset_version=17,
+            do_constant_folding=True,
+            input_names=['input'],
+            output_names=['output'],
+        )
+        print(f"Model successfully converted to ONNX format at {onnx_file_path}")
+    except Exception as e:
+        print("Error during ONNX export:", e)

--- a/tests/test_istft.py
+++ b/tests/test_istft.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2025 Mixxx Development Team
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+# First author is Anmol Mishra.
+"""
+Test to compare the iSTFT outputs from PyTorch's iSTFT and ONNX exportable iSTFT.
+"""
+from demucs.spec import ispectro
+import pytest
+import torch
+
+
+def ispectroAPI(z, hop_length=None, length=None, pad=0):
+    return NotImplementedError("This function is just a placeholder for the ispectro function.")
+
+@pytest.fixture(scope='session')
+def input_spectrogram():
+    """ Fixture to generate a random spectrogram for testing """
+    batch, sources, channels = 1, 4, 2
+    samples, n_fft, hop_length = int(7.8 * 44100), 4096, 1024
+    freq_bins, time_steps = n_fft//2 + 1 , samples//hop_length + 1
+
+    z = torch.randn(batch, sources, channels, freq_bins, time_steps, 2)  # (batch, sources, channels, freq_bins, time_steps, 2)
+    return z, samples, hop_length
+
+def test_istft_shape_pytorch(input_spectrogram):
+    """ Test the shape of the iSTFT output using PyTorch's iSTFT """
+    z, samples, hop_length = input_spectrogram
+    batch, sources, channels = z.shape[0], z.shape[1], z.shape[2]
+    x = ispectro(torch.view_as_complex(z), hop_length=hop_length, length=samples, onnx_exportable=False)
+
+    assert x.shape == (batch, sources, channels, samples)  # (batch, sources, channels, samples)
+
+def test_istft_shape_onnx_compatible(input_spectrogram):
+    """ Test the shape of the iSTFT output using ONNX compatible iSTFT """
+    z, samples, hop_length = input_spectrogram
+    batch, sources, channels = z.shape[0], z.shape[1], z.shape[2]
+    x = ispectro(z, hop_length=hop_length, length=samples, onnx_exportable=True)
+
+    assert x.shape == (batch, sources, channels, samples)  # (batch, sources, channels, samples)
+
+def test_compare_istfts(input_spectrogram):
+    """ Compare the iSTFTs from PyTorch and ONNX compatible iSTFT """
+    z, samples, hop_length = input_spectrogram
+
+    x_pytorch = ispectro(torch.view_as_complex(z), hop_length=hop_length, length=samples-hop_length, onnx_exportable=False)
+    x_onnx = ispectro(z, hop_length=hop_length, length=samples-hop_length, onnx_exportable=True)
+
+    # Calculate the mean difference between the two iSTFTs
+    mean_diff = torch.abs(x_pytorch - x_onnx).mean().item()
+    print("\niSTFT Result: Mean Difference =", mean_diff)
+
+    assert mean_diff < 1e-4, "iSTFTs do not match!"

--- a/tests/test_onnx_flag.py
+++ b/tests/test_onnx_flag.py
@@ -1,3 +1,13 @@
+# Copyright (C) 2025 Mixxx Development Team
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+# First author is Anmol Mishra.
+"""
+Test for the HTDemucs model ONNX export branch functionality.
+"""
+
 from demucs.htdemucs import HTDemucs
 import pytest
 import torch

--- a/tests/test_onnx_flag.py
+++ b/tests/test_onnx_flag.py
@@ -29,6 +29,9 @@ def test_onnx_flag(htdemucs_model, input_waveform):
     # Now set onnx_exportable to True to get the ONNX path output
     htdemucs_model.onnx_exportable = True
     output_onnx = htdemucs_model(input_waveform)
-    
-    # Check if the outputs are identical
-    assert torch.allclose(output, output_onnx, atol=1e-5), "Outputs should be identical for onnx_exportable=False and True"
+
+    # Calculate the mean difference between the two outputs
+    mean_diff = torch.abs(output_onnx - output).mean().item()
+    print("Output Result: Mean Difference =", mean_diff)
+
+    assert mean_diff < 1e-4, "Outputs should be identical for onnx_exportable=False and True"

--- a/tests/test_onnx_flag.py
+++ b/tests/test_onnx_flag.py
@@ -1,0 +1,24 @@
+from demucs.htdemucs import HTDemucs
+import pytest
+import torch
+
+@pytest.fixture
+def htdemucs_model():
+    return HTDemucs(sources=['drums', 'bass', 'other', 'vocals'])
+
+@pytest.fixture
+def input_waveform():
+    batch, channels, samples = 1, 2, int(44100 * 7.8)  # 7.8 seconds of audio at 44100 Hz is the expected input waveform for HTDemucs
+    return torch.randn(batch, channels, samples)
+
+def test_onnx_flag(htdemucs_model, input_waveform):
+    # Run forward pass with default complex tensor path
+    htdemucs_model.onnx_exportable = False  # The default state
+    output = htdemucs_model(input_waveform)
+
+    # Now set onnx_exportable to True to get the ONNX path output
+    htdemucs_model.onnx_exportable = True
+    output_onnx = htdemucs_model(input_waveform)
+    
+    # Check if the outputs are identical
+    assert torch.allclose(output, output_onnx, atol=1e-5), "Outputs should be identical for onnx_exportable=False and True"

--- a/tests/test_stft.py
+++ b/tests/test_stft.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2025 Mixxx Development Team
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+# First author is Anmol Mishra.
+"""
+Test to compare the spectrogram outputs from PyTorch's STFT and ONNX exportable STFT.
+"""
+from demucs.spec import spectro
+import pytest
+import torch
+
+def spectroAPI(x, n_fft=512, hop_length=None, pad=0):
+    return NotImplementedError("This function is just a placeholder for the spectro function.")
+
+@pytest.fixture(scope='session')
+def input_waveform():
+    batch, channels, samples = 1, 2, int(7.8*44100)  # 7.8 seconds of audio at 44100 Hz
+    yield torch.randn(batch, channels, samples)
+
+def test_spectrogram_shape_pytorch(input_waveform):
+    """ Test the shape of the spectrogram output using PyTorch's STFT """
+    b, c, s = input_waveform.shape
+    n_fft, hop_length = 4096, 1024
+    spec = spectro(input_waveform, n_fft=n_fft, hop_length=hop_length, pad=0, onnx_exportable=False)
+    
+    assert spec.shape == (b, c, n_fft // 2 + 1, s // hop_length + 1)  # (batch, channels, freq_bins, time_steps)
+
+def test_spectrogram_shape_onnx_exportable(input_waveform):
+    """ Test the shape of the spectrogram output using ONNX exportable STFT """
+    b, c, s = input_waveform.shape
+    n_fft, hop_length = 4096, 1024
+    spec = spectro(input_waveform, n_fft=n_fft, hop_length=hop_length, pad=0, onnx_exportable=True)
+    
+    assert spec.shape == (b, c, n_fft // 2 + 1, s // hop_length + 1, 2)  # (batch, channels, freq_bins, time_steps, 2)
+
+def test_compare_spectrograms(input_waveform):
+    """ Compare the spectrograms from PyTorch and ONNX exportable STFT """
+    n_fft, hop_length = 4096, 1024
+    spec_pytorch = torch.view_as_real(
+        spectro(input_waveform, n_fft=n_fft, hop_length=hop_length, pad=0, onnx_exportable=False)
+    )   # Convert to real tensor for comparison
+    spec_onnx = spectro(input_waveform, n_fft=n_fft, hop_length=hop_length, pad=0, onnx_exportable=True)
+
+    # Calculate the mean difference between the two spectrograms
+    mean_diff = torch.abs(spec_pytorch - spec_onnx).mean().item()
+    print("STFT Result: Mean Difference =", mean_diff)
+
+    assert mean_diff < 1e-4, "Spectrograms do not match!"


### PR DESCRIPTION
In this PR, I've modified the STFT and ISTFT layers to be ONNX exportable. 
Details of the changes are documented in this blog - [Mixxx Blog Link](https://mixxx.org/news/2025-10-27-gsoc2025-demucs-to-onnx-dhunstack/)

The exported model measures closely on the MusDB benchmark. 

| Stem              | PyTorch Model (dB) | ONNX Model (C++) (dB) |
|--------------|---------------------|-------------------------|
| drums.wav     |  9.46                          |  9.47                                 |
| bass.wav        |  7.76                          |   7.77                                 |
| other.wav       |  4.69                          |  4.65                                 |
| vocals.wav     |  7.84                          |   7.83                                 | 
| **Overall**    | **7.44**                     | **7.43**.                           |


*Table: SI-SDR (dB) comparison for each stem and overall, using torchmetrics. Results are shown for the native PyTorch model and the exported ONNX model running in C++.*